### PR TITLE
:sparkles:  Add setting to turn off HLC on "sleep" mode

### DIFF
--- a/HLCpattern.install
+++ b/HLCpattern.install
@@ -1,7 +1,7 @@
 {
 	"name": "HLCpattern",
 	"speakableName": "LED pattern selector",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"icon": "fas fa-traffic-light",
 	"category": "assistance",
 	"author": "lazza",

--- a/HLCpattern.py
+++ b/HLCpattern.py
@@ -157,3 +157,17 @@ class HLCpattern(AliceSkill):
 	def cleanupTempFiles(self):
 		""" Delete temporary file """
 		self.Commons.runSystemCommand(f'rm -rf {self._hlcTempPath}'.split())
+
+
+	def onSleep(self):
+		super().onSleep()
+		if self.getConfig('disableHLConSleep'):
+			self.Commons.runSystemCommand('sudo systemctl stop hermesledcontrol'.split())
+			self.logInfo('Disabled HLC, sleep well')
+
+
+	def onWakeup(self):
+		super().onWakeup()
+		if self.getConfig('disableHLConSleep'):
+			self.Commons.runSystemCommand('sudo systemctl start hermesledcontrol'.split())
+			self.logInfo('Good morning, HLC has been re enabled')

--- a/config.json.template
+++ b/config.json.template
@@ -1,0 +1,8 @@
+{
+	"disableHLConSleep": {
+		"defaultValue": false,
+		"dataType": "boolean",
+		"isSensitive": false,
+		"description": "Disable HLC at night time"
+	}
+}


### PR DESCRIPTION
##### Summary

With the skills setting "disableHLConSleep" enabled. Alice will turn off her LED's when you are sleeping and turn them back on again when the mode changes to wakeup (onWakeUp) (or when she re starts). It does this via sudo systemctl stop and start hermesledcontrol 

##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring
- [ ] Other, please describe:

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [ ] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [x] You have tested your changes on the branch you wish to merge
- [x] The changes are working


If adding a **new feature**, the PR's description includes:

- [x] The reason for this new feature to be added
- [x] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information: